### PR TITLE
Tab char Error handling

### DIFF
--- a/app/assembler.js
+++ b/app/assembler.js
@@ -32,7 +32,7 @@ const CharSet =
       + '"'                      // quotes
       + "'"                      // quotes
       + ".$[]()+-*"                // punctuation
-      + "?¬£`<=>!%^&{}#~@:|/\\";   // other
+      + "?Â¬Â£`<=>!%^&{}#~@:|/\\";   // other
 
 function validateChars (xs) {
     console.log (`validateChars`);
@@ -836,7 +836,7 @@ function asmPass1 (m) {
     for (let i = 0; i < asmSrcLines.length; i++) {
 	m.asmStmt[i] = mkAsmStmt (i, m.locationCounter, asmSrcLines[i]);
 	let s = m.asmStmt[i];
-        let badCharLocs = validateChars (asmSrcLines[i]);
+        let badCharLocs = validateChars (asmSrcLines[i].replace(/\t/g,'')));
         if (badCharLocs.length > 0) {
             mkErrMsg (m,s,`Invalid character at position ${badCharLocs}`);
             mkErrMsg (m,s, "See User Guide for list of valid characters");


### PR DESCRIPTION
Few friends got stuck on the Invalid character Error, because they pasted code from another editor, which included tab char. This is very quick fix.